### PR TITLE
Safely deleting the fibre when degrading it

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -998,7 +998,7 @@ void Cell::degrade_fibre(Cell *fibre_to_degrade) {
     // remove fibre from agent grid
     (*fibre_to_degrade).get_container()->remove_agent(fibre_to_degrade);
     // de-allocate (delete) the cell;
-    delete (fibre_to_degrade);
+    fibre_to_degrade->flag_for_removal();
     //}
 }
 


### PR DESCRIPTION
Degraded fibers where deleted directly, without using the flag_for_removal() function. One way to fix it is to use the flag_for_removal() instead of delete. But maybe there is a better way, I'm still investigating, so if you need the fix now this works, otherwise I can have a deeper look in the next days.